### PR TITLE
[documentation] Update instructions in building_for_linux.md

### DIFF
--- a/building_for_linux.md
+++ b/building_for_linux.md
@@ -15,7 +15,7 @@ This document describes the process to build Ocean on Linux.
       xz-devel
 
   # Ubuntu
-  sudo apt-get install libx11-dev libudev-dev liblzma-dev libgl1-mesa-dev
+  sudo apt-get install libx11-dev libudev-dev liblzma-dev libgl1-mesa-dev libxcb-glx0-dev
   ```
 
 ## 2 Building the third-party libraries


### PR DESCRIPTION
According to issue #19, the package `libxcb-glx0-dev` is required for some OpenGL headers needed by the X windowing system.
