### PR TITLE
[cmake] Fix config of iOS test apps

### DIFF
--- a/impl/application/ocean/test/base/testbase/CMakeLists.txt
+++ b/impl/application/ocean/test/base/testbase/CMakeLists.txt
@@ -102,6 +102,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestBase.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/base/testbase/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/cv/testcv/CMakeLists.txt
+++ b/impl/application/ocean/test/cv/testcv/CMakeLists.txt
@@ -109,6 +109,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestCV.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/cv/testcv/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/cv/testcv/testadvanced/CMakeLists.txt
+++ b/impl/application/ocean/test/cv/testcv/testadvanced/CMakeLists.txt
@@ -103,6 +103,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestCVAdvanced.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/cv/testcv/testadvanced/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/cv/testcv/testdetector/CMakeLists.txt
+++ b/impl/application/ocean/test/cv/testcv/testdetector/CMakeLists.txt
@@ -106,6 +106,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestCVDetector.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/cv/testcv/testdetector/ios/*.storyboard")
     file(GLOB OCEAN_TARGET_IMAGE_RESOURCES
         "${CMAKE_SOURCE_DIR}/res/application/ocean/test/cv/testcv/testdetector/ios/*.bmp"

--- a/impl/application/ocean/test/cv/testcv/testdetector/testqrcodes/CMakeLists.txt
+++ b/impl/application/ocean/test/cv/testcv/testdetector/testqrcodes/CMakeLists.txt
@@ -104,6 +104,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestCVDetectorQRCodes.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/cv/testcv/testdetector/testqrcodes/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/cv/testcv/testsegmentation/CMakeLists.txt
+++ b/impl/application/ocean/test/cv/testcv/testsegmentation/CMakeLists.txt
@@ -104,6 +104,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestCVSegmentation.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/cv/testcv/testsegmentation/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/geometry/testgeometry/CMakeLists.txt
+++ b/impl/application/ocean/test/geometry/testgeometry/CMakeLists.txt
@@ -102,6 +102,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestGeometry.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/geometry/testgeometry/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/math/testmath/CMakeLists.txt
+++ b/impl/application/ocean/test/math/testmath/CMakeLists.txt
@@ -101,6 +101,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestMath.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/math/testmath/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/media/testmedia/CMakeLists.txt
+++ b/impl/application/ocean/test/media/testmedia/CMakeLists.txt
@@ -102,6 +102,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestMedia.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/media/testmedia/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/platform/testplatform/CMakeLists.txt
+++ b/impl/application/ocean/test/platform/testplatform/CMakeLists.txt
@@ -57,6 +57,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestPlatform.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/platform/testplatform/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}

--- a/impl/application/ocean/test/tracking/testtracking/CMakeLists.txt
+++ b/impl/application/ocean/test/tracking/testtracking/CMakeLists.txt
@@ -100,6 +100,9 @@ if (IOS)
         "${CMAKE_CURRENT_LIST_DIR}/ios/*.mm"
     )
 
+    # Exclude files that are intended for the Desktop version of this application.
+    list(REMOVE_ITEM OCEAN_TARGET_SOURCE_FILES "${CMAKE_CURRENT_LIST_DIR}/TestTracking.cpp")
+
     file(GLOB OCEAN_TARGET_STORYBOARDS "${CMAKE_SOURCE_DIR}/res/application/ocean/test/tracking/testtracking/ios/*.storyboard")
 
     add_executable(${OCEAN_TARGET_NAME}


### PR DESCRIPTION
The list of source files of these apps included files that are only meant for the desktop versions of these test apps. They need to be excluded from iOS builds in order to avoid linker errors about duplicate symbols similar to this:

```
ld: warning: ignoring duplicate libraries: '/Users/nils/build_ocean_ios_release/impl/ocean/base/Debug-iphoneos/libocean_base.a', '/Users/nils/build_ocean_ios_release/impl/ocean/test/testcv/Debug-iphoneos/libocean_test_testcv.a'
duplicate symbol '_main' in:
    /Users/nils/build_ocean_ios_release/build/application_ocean_test_cv_testcv_testsegmentation_ios.build/Debug-iphoneos/Objects-normal/arm64/Main.o
    /Users/nils/build_ocean_ios_release/build/application_ocean_test_cv_testcv_testsegmentation_ios.build/Debug-iphoneos/Objects-normal/arm64/TestCVSegmentation.o
ld: 1 duplicate symbols
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
Test plan:

On a Mac, follow the instructions for iOS builds:

https://github.com/facebookresearch/ocean/blob/main/building_for_ios.md

Then, build, install, and start each of the following targets from XCode:

* `application_ocean_test_base_testbase_ios`
* `application_ocean_test_cv_testcv_ios`
* `application_ocean_test_cv_testcv_testadvanced_ios`
* `application_ocean_test_cv_testcv_testdetector_ios`
* `application_ocean_test_cv_testcv_testdetector_testqrcodes_ios`
* `application_ocean_test_cv_testcv_testsegmentation_ios`
* `application_ocean_test_geometry_testgeometry_ios`
* `application_ocean_test_math_testmath_ios`
* `application_ocean_test_media_testmedia_ios`
* `application_ocean_test_platform_testplatform_ios`
* `application_ocean_test_tracking_testtracking_ios`
