### PR TITLE
[workflow] Reduce number of runs

### DIFF
--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -3,8 +3,6 @@
 name: Build Ocean on Linux (static)
 
 on:
-  pull_request:
-    branches: [main]
   schedule:
     # Execute this workflow:
     # Mon-Sun, every 24 hours at 6 am (UTC)


### PR DESCRIPTION
Currently this work flow build and tests the entire framework for both, debug and release config. This takes 4-5h. These workflow needs to be more granular so that they test only what needs to be tested. Until then, let's stop running these on pull requests and instead rely on common sense, internal and local testing. The regular workflow builds—every 24h during the week—will be maintained, though.

Test plan:
CI
