### PR TITLE
[cmake] Disable deprecation warning in iOS builds

### DIFF
--- a/impl/application/ocean/demo/cv/detector/linedetector/CMakeLists.txt
+++ b/impl/application/ocean/demo/cv/detector/linedetector/CMakeLists.txt
@@ -225,6 +225,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/demo/cv/detector/messengercode/CMakeLists.txt
+++ b/impl/application/ocean/demo/cv/detector/messengercode/CMakeLists.txt
@@ -218,6 +218,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/demo/cv/detector/qrcodes/detector2d/CMakeLists.txt
+++ b/impl/application/ocean/demo/cv/detector/qrcodes/detector2d/CMakeLists.txt
@@ -203,6 +203,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/demo/media/videopreview/CMakeLists.txt
+++ b/impl/application/ocean/demo/media/videopreview/CMakeLists.txt
@@ -156,6 +156,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/demo/tracking/featuretracker/CMakeLists.txt
+++ b/impl/application/ocean/demo/tracking/featuretracker/CMakeLists.txt
@@ -256,6 +256,8 @@ if (IOS)
         ${OCEAN_TARGET_IMAGE_RESOURCES}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set_source_files_properties(${OCEAN_TARGET_IMAGE_RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 

--- a/impl/application/ocean/demo/tracking/homographyimagealigner/CMakeLists.txt
+++ b/impl/application/ocean/demo/tracking/homographyimagealigner/CMakeLists.txt
@@ -220,6 +220,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/demo/tracking/homographytracker/CMakeLists.txt
+++ b/impl/application/ocean/demo/tracking/homographytracker/CMakeLists.txt
@@ -222,6 +222,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/demo/tracking/pointtracker/CMakeLists.txt
+++ b/impl/application/ocean/demo/tracking/pointtracker/CMakeLists.txt
@@ -220,6 +220,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/demo/tracking/similaritytracker/CMakeLists.txt
+++ b/impl/application/ocean/demo/tracking/similaritytracker/CMakeLists.txt
@@ -219,6 +219,8 @@ if (IOS)
         ${OCEAN_TARGET_STORYBOARDS}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
     set(ALL_APP_RESOURCES

--- a/impl/application/ocean/shark/CMakeLists.txt
+++ b/impl/application/ocean/shark/CMakeLists.txt
@@ -110,6 +110,8 @@ if (IOS)
         ${OCEAN_TARGET_RESOURCES}
     )
 
+    target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+
     set_source_files_properties(${OCEAN_TARGET_STORYBOARDS} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
     set_source_files_properties(${OCEAN_TARGET_RESOURCES} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 

--- a/impl/ocean/platform/apple/ios/CMakeLists.txt
+++ b/impl/ocean/platform/apple/ios/CMakeLists.txt
@@ -22,7 +22,14 @@ if (IOS)
 
     target_include_directories(${OCEAN_TARGET_NAME} PUBLIC "${OCEAN_IMPL_DIR}")
 
-    target_compile_definitions(${OCEAN_TARGET_NAME} PUBLIC ${OCEAN_PREPROCESSOR_FLAGS})
+    target_compile_definitions(${OCEAN_TARGET_NAME} 
+        PUBLIC 
+            ${OCEAN_PREPROCESSOR_FLAGS}
+
+        PRIVATE 
+            "-DGLES_SILENCE_DEPRECATION"
+    )
+
     target_compile_options(${OCEAN_TARGET_NAME} PUBLIC ${OCEAN_COMPILER_FLAGS})
 
     # Dependencies

--- a/impl/ocean/rendering/glescenegraph/CMakeLists.txt
+++ b/impl/ocean/rendering/glescenegraph/CMakeLists.txt
@@ -50,7 +50,9 @@ if (ANDROID OR IOS OR LINUX OR MACOS OR WIN32)
         target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DUSE_OCEAN_RENDERING_GLES_EXPORT")
     endif()
 
-    if (IOS OR MACOS)
+    if (IOS)
+        target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+    elseif (MACOS)
         target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGL_SILENCE_DEPRECATION")
     endif()
 

--- a/impl/ocean/rendering/glescenegraph/apple/CMakeLists.txt
+++ b/impl/ocean/rendering/glescenegraph/apple/CMakeLists.txt
@@ -23,7 +23,13 @@ if (MACOS OR IOS)
         PUBLIC
             ${OCEAN_COMPILER_FLAGS}
             "-fexceptions"
-        )
+    )
+
+    if (IOS)
+        target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGLES_SILENCE_DEPRECATION")
+    elseif (MACOS)
+        target_compile_definitions(${OCEAN_TARGET_NAME} PRIVATE "-DGL_SILENCE_DEPRECATION")
+    endif()
 
     # Dependencies
     target_link_libraries(${OCEAN_TARGET_NAME}


### PR DESCRIPTION
This change silences compiler warnings about the deprecation of the OpenGL API on iOS. The warning are similar to this:

```
.../ocean/impl/ocean/rendering/glescenegraph/GLESShaderProgram.h:448:28: 'glGetUniformLocation' is deprecated: first deprecated in iOS 12.0 - OpenGLES API deprecated. (Define GLES_SILENCE_DEPRECATION to silence these warnings)
```

Test plan:

Follow the instructions for building iOS apps with XCode and repeat this for the following apps:

* `application_ocean_demo_base_console_ios`
* `application_ocean_demo_cv_detector_linedetector_ios`
* `application_ocean_demo_cv_detector_messengercode_ios`
* `application_ocean_demo_cv_detector_qrcodes_detector2d_ios`
* `application_ocean_demo_media_videopreview_ios`
* `application_ocean_demo_tracking_featuretracker_ios`
* `application_ocean_demo_tracking_homographyimagealigner_ios`
* `application_ocean_demo_tracking_homographytracker_ios`
* `application_ocean_demo_tracking_pointtracker_ios`
* `application_ocean_demo_tracking_similaritytracker_ios`
* `application_ocean_shark_ios`

Observe that there are no longer any deprecation warnings about OpenGL.

