### PR TITLE
Update to use FetchContent_MakeAvailable, and avoid build errors due to using the same directory and now use unique directory

### DIFF
--- a/build/cmake/third-party/CPM.cmake
+++ b/build/cmake/third-party/CPM.cmake
@@ -1006,8 +1006,8 @@ function(cpm_fetch_package PACKAGE populated)
 
   if(NOT ${lower_case_name}_POPULATED)
   FetchContent_MakeAvailable(${PACKAGE})
-  set(${lower_case_name}_POPULATED
-      TRUE
+  set(${populated}
+        TRUE
       PARENT_SCOPE
   )
   endif()

--- a/build/cmake/third-party/CPM.cmake
+++ b/build/cmake/third-party/CPM.cmake
@@ -1009,7 +1009,7 @@ function(cpm_fetch_package PACKAGE populated)
     set(${populated}
         TRUE
         PARENT_SCOPE
-  )
+    )
   endif()
 
   cpm_store_fetch_properties(

--- a/build/cmake/third-party/CPM.cmake
+++ b/build/cmake/third-party/CPM.cmake
@@ -1005,11 +1005,11 @@ function(cpm_fetch_package PACKAGE populated)
   string(TOLOWER "${PACKAGE}" lower_case_name)
 
   if(NOT ${lower_case_name}_POPULATED)
-    FetchContent_Populate(${PACKAGE})
-    set(${populated}
-        TRUE
-        PARENT_SCOPE
-    )
+  FetchContent_MakeAvailable(${PACKAGE})
+  set(${lower_case_name}_POPULATED
+      TRUE
+      PARENT_SCOPE
+  )
   endif()
 
   cpm_store_fetch_properties(

--- a/build/cmake/third-party/CPM.cmake
+++ b/build/cmake/third-party/CPM.cmake
@@ -804,11 +804,12 @@ function(CPMAddPackage)
       file(LOCK ${download_directory}/../cmake.lock RELEASE)
     endif()
     if(${populated})
+      set(unique_binary_dir "${${CPM_ARGS_NAME}_BINARY_DIR}_${CPM_ARGS_VERSION}")
       cpm_add_subdirectory(
         "${CPM_ARGS_NAME}"
         "${DOWNLOAD_ONLY}"
         "${${CPM_ARGS_NAME}_SOURCE_DIR}/${CPM_ARGS_SOURCE_SUBDIR}"
-        "${${CPM_ARGS_NAME}_BINARY_DIR}"
+        "${unique_binary_dir}"
         "${CPM_ARGS_EXCLUDE_FROM_ALL}"
         "${CPM_ARGS_SYSTEM}"
         "${CPM_ARGS_OPTIONS}"

--- a/build/cmake/third-party/CPM.cmake
+++ b/build/cmake/third-party/CPM.cmake
@@ -1005,10 +1005,10 @@ function(cpm_fetch_package PACKAGE populated)
   string(TOLOWER "${PACKAGE}" lower_case_name)
 
   if(NOT ${lower_case_name}_POPULATED)
-  FetchContent_MakeAvailable(${PACKAGE})
-  set(${populated}
-        TRUE
-      PARENT_SCOPE
+    FetchContent_MakeAvailable(${PACKAGE})
+    set(${populated}
+          TRUE
+        PARENT_SCOPE
   )
   endif()
 

--- a/build/cmake/third-party/CPM.cmake
+++ b/build/cmake/third-party/CPM.cmake
@@ -1007,7 +1007,7 @@ function(cpm_fetch_package PACKAGE populated)
   if(NOT ${lower_case_name}_POPULATED)
     FetchContent_MakeAvailable(${PACKAGE})
     set(${populated}
-          TRUE
+        TRUE
         PARENT_SCOPE
   )
   endif()


### PR DESCRIPTION
**Pull Request Template**

**Summary**

* Briefly describe the changes made in this pull request:
  + FetchContent_Populate is deprecated, so migrate to use FetchContent_MakeAvailable
  + I got errors when buildling for the first time, regarding the directory, this change fixed it for me.

**Changes**

* Describe the changes made in this pull request:
  + Few changes in Cmake file

**Motivation**

* Explain the motivation behind making these changes:
  + Improve experience when onboarding and building

**Testing**

* Describe the testing performed to verify the changes:
  + [Insert testing details]
  + Include information about:
    - Test cases added or modified
    - Results of testing

**Checklist**

* Confirm that the following have been completed:
  + [ ] Code compiles and runs successfully on all supported platforms
  + [ ] All tests pass
  + [ ] Documentation is updated (if applicable)
  + [ ] Changes follow the project's coding standards

**Additional Comments**

* Any additional comments or information that may be helpful:
  + [Insert additional comments]
