### PR TITLE
Fix double square rooting in ORB sampling pattern

### DIFF
--- a/impl/ocean/cv/detector/ORBSamplingPattern.cpp
+++ b/impl/ocean/cv/detector/ORBSamplingPattern.cpp
@@ -342,7 +342,7 @@ ORBSamplingPattern::LookupTables ORBSamplingPattern::createLookupTables(const un
 			ocean_assert(point0.x() > -threshold && point0.x() < threshold);
 			ocean_assert(point1.y() > -threshold && point1.y() < threshold);
 
-			const Scalar layerFactor = Numeric::sqrt(Scalar(1.41421)); // sqrt(2)
+			const Scalar layerFactor = Scalar(1.41421); // sqrt(2)
 
 			constexpr Scalar layerThreshold = Scalar(26);
 


### PR DESCRIPTION
**Pull Request Template**

**Summary**

- Removed double square rooting in ORB sampling pattern.

**Changes**

* Describe the changes made in this pull request:
- When observing the code, it seemed like there was double square rooting. The author probably meant just using sqrt(2), but then calculated the values and wrapped it within sqrt function again?

**Motivation**
- Been learning from the code, and noticed a potential mistake. Want to contribute!

**Testing**
- Have not yet tested on the code. CI test and on-device test must be taken.

**Checklist**

* Confirm that the following have been completed:
  + [ ] Code compiles and runs successfully on all supported platforms
  + [ ] All tests pass
  + [ ] Documentation is updated (if applicable)
  + [ ] Changes follow the project's coding standards

**Additional Comments**
