### PR TITLE
Make minimal ocean build even smaller

### DIFF
--- a/impl/ocean/cv/CMakeLists.txt
+++ b/impl/ocean/cv/CMakeLists.txt
@@ -5,14 +5,14 @@
 
 cmake_minimum_required(VERSION 3.26)
 
-add_subdirectory(advanced)
-add_subdirectory(depth)
-add_subdirectory(detector)
 if (NOT OCEAN_BUILD_MINIMAL)
+    add_subdirectory(advanced)
+    add_subdirectory(depth)
+    add_subdirectory(detector)
     add_subdirectory(fonts)
+    add_subdirectory(segmentation)
+    add_subdirectory(synthesis)
 endif()
-add_subdirectory(segmentation)
-add_subdirectory(synthesis)
 
 if (MACOS OR ANDROID OR IOS OR LINUX OR WIN32)
 


### PR DESCRIPTION
Summary: The option OCEAN_BUILD_MINIMAL avoids building unecessary targets, but even within the CV component, we can limit what's built for a really minimal build.

Differential Revision: D68639032


