### PR TITLE
Refactor buildDate() to use string_views

### DIFF
--- a/impl/ocean/base/Build.cpp
+++ b/impl/ocean/base/Build.cpp
@@ -8,6 +8,7 @@
 #include "ocean/base/Build.h"
 #include "ocean/base/String.h"
 
+#include <charconv>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
@@ -235,22 +236,20 @@ std::string Build::buildString()
 	return result;
 }
 
-std::string Build::buildDate(const char* d)
+std::string Build::buildDate(const std::string_view date)
 {
-	std::string dateStr(d);
+	ocean_assert(date.length() == 11);
 
-	ocean_assert(dateStr.length() == 11);
-
-	if (dateStr.length() != 11)
+	if (date.length() != 11)
 	{
 		return std::string();
 	}
 
-	const std::string months[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+	static constexpr std::string_view months[12] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
-	std::string monthStr = dateStr.substr(0, 3);
-	std::string dayStr = dateStr.substr(4, 2);
-	std::string yearStr = dateStr.substr(7, 4);
+	const std::string_view monthStr = date.substr(0, 3);
+	const std::string_view dayStr   = date.substr(4, 2);
+	const std::string_view yearStr  = date.substr(7, 4);
 
 	unsigned int month = 0u;
 	for (unsigned int n = 0u; n < 12; n++)
@@ -268,8 +267,15 @@ std::string Build::buildDate(const char* d)
 		return std::string();
 	}
 
-	unsigned int day = atoi(dayStr.c_str());
-	unsigned int year = atoi(yearStr.c_str());
+    const auto parseNumber = [](const std::string_view number){
+		unsigned int parsed;
+        auto [ptr, errorCode] = std::from_chars(number.data(), number.data() + number.length(), parsed);
+		// Assert that there was no error in parsing
+		ocean_assert(errorCode == std::errc());
+		return parsed;
+	};
+	const unsigned int day  = parseNumber(dayStr);
+	const unsigned int year = parseNumber(yearStr);
 
 	ocean_assert(day >= 1 && day <= 31);
 	if (day < 1 || day > 31)

--- a/impl/ocean/base/Build.cpp
+++ b/impl/ocean/base/Build.cpp
@@ -251,15 +251,16 @@ std::string Build::buildDate(const std::string_view date)
 	const std::string_view dayStr   = date.substr(4, 2);
 	const std::string_view yearStr  = date.substr(7, 4);
 
-	unsigned int month = 0u;
-	for (unsigned int n = 0u; n < 12; n++)
-	{
-		if (months[n] == monthStr)
+	const unsigned int month = [&](){
+		for (unsigned int n = 0u; n < 12; n++)
 		{
-		  month = n + 1u;
-		  break;
+			if (months[n] == monthStr)
+			{
+		  		return n + 1u;
+			}
 		}
-	}
+		return 0u;
+	}();
 
 	ocean_assert(month >= 1 && month <= 12);
 	if (month < 1 || month > 12)

--- a/impl/ocean/base/Build.h
+++ b/impl/ocean/base/Build.h
@@ -67,7 +67,7 @@ class OCEAN_BASE_EXPORT Build
 		 * @param date Compiler build date which must be __DATE__
 		 * @return Date of build process
 		 */
-		static std::string buildDate(const char* date);
+		static std::string buildDate(const std::string_view date);
 
 		/**
 		 * Returns the time of the compiler building process as string.

--- a/impl/ocean/test/testbase/TestDateTime.cpp
+++ b/impl/ocean/test/testbase/TestDateTime.cpp
@@ -12,6 +12,7 @@
 #include "ocean/base/RandomI.h"
 #include "ocean/base/String.h"
 #include "ocean/base/Timestamp.h"
+#include "ocean/base/Build.h"
 
 namespace Ocean
 {
@@ -32,6 +33,7 @@ bool TestDateTime::test(const double testDuration)
 	bool allSucceeded = true;
 
 	allSucceeded = testConversion(testDuration) && allSucceeded;
+	allSucceeded = testBuildDate()              && allSucceeded;
 
 	Log::info() << " ";
 
@@ -177,6 +179,24 @@ bool TestDateTime::testConversion(const double testDuration)
 	}
 
 	return allSucceeded;
+}
+
+bool TestDateTime::testBuildDate()
+{
+	Log::info() << "buildDate test:";
+
+    static const std::string testData = "Jan 02 1970";
+	static const std::string expected = "1970.01.02";
+	const std::string actual          = Build::buildDate(testData.c_str());
+	if(expected == actual)
+	{
+		Log::info() << "Validation: succeeded.";
+	}
+	else
+	{
+		Log::info() << "Validation: FAILED!";
+	}
+	return expected == actual;
 }
 
 }

--- a/impl/ocean/test/testbase/TestDateTime.h
+++ b/impl/ocean/test/testbase/TestDateTime.h
@@ -40,6 +40,12 @@ class OCEAN_TEST_BASE_EXPORT TestDateTime
 		 * @return True, if succeeded
 		 */
 		static bool testConversion(const double testDuration);
+
+		/**
+		 * Tests the Build::buildDate() function
+		 * @return True, if succeeded
+		 */
+		static bool testBuildDate();
 };
 
 }


### PR DESCRIPTION
**Pull Request Template**

**Summary**

* This refactors the `Build::buildDate()` utility function to use `std::string_view`s for performance and safety, and adds test cases to verify the functionality.

**Changes**
* Adds a singular test case for `Build::buildDate()`
* Refactors `Build::buildDate()` to use `std::string_view` as a parameter and for intermediate variables
  + Also refactors a `static const` array of `std::string` to be a `static constexpr` array of `std::string_view`.
* Also refactors a variable to be initialized with an IIFE

**Motivation**

* Performance, as this prevents 4 temporary strings from being created whenever the `Build::buildDate()` function is called.
* Additionally, `static constexpr std::string_view`s are initialized at compile-time instead of run-time.

**Testing**

* No previous unit tests were available for `Build::buildDate()`, so I added one that tests the date "Jan 2, 1970".
* This passed before and after.

**Checklist**

* Confirm that the following have been completed:
  + [ ] Code compiles and runs successfully on all supported platforms
  + [ ] All tests pass
  + [ ] Documentation is updated (if applicable)
  + [ ] Changes follow the project's coding standards

**Additional Comments**

* I'm not experienced with making PRs to large corporate projects on GitHub and I haven't contributed to this repo before. I would also like to refactor more `std::string`s into `std::string_view`s but I'm unsure of whether this'd be welcome, so I haven't included commits updating the style guide.
