### PR TITLE
Fix findOutline4 emitting interior mask pixels as outline pixels

### DIFF
--- a/impl/ocean/cv/segmentation/MaskAnalyzer.cpp
+++ b/impl/ocean/cv/segmentation/MaskAnalyzer.cpp
@@ -445,7 +445,7 @@ void MaskAnalyzer::findOutline4(const uint8_t* mask, const unsigned int width, c
 
 		for (unsigned int x = std::max(1u, firstColumn); x < std::min(endColumn, width_1); ++x)
 		{
-			if (maskRow[x - 1u] != nonMaskValue || maskRow[x + 1u] != nonMaskValue || maskRowTop[x] != nonMaskValue || maskRowBottom[x] != nonMaskValue)
+			if (maskRow[x] == nonMaskValue && (maskRow[x - 1u] != nonMaskValue || maskRow[x + 1u] != nonMaskValue || maskRowTop[x] != nonMaskValue || maskRowBottom[x] != nonMaskValue))
 			{
 				outlinePixels4.emplace_back(x, y);
 			}


### PR DESCRIPTION
## Problem

`MaskAnalyzer::findOutline4` (impl/ocean/cv/segmentation/MaskAnalyzer.cpp) documents its result as: "the pixel itself is not a mask pixel but has at least one neighbor mask pixel in the four-neighborhood" (see MaskAnalyzer.h).

However, the center-rows pass only checked the four-neighborhood of each pixel:

```cpp
if (maskRow[x - 1u] != nonMaskValue || maskRow[x + 1u] != nonMaskValue || maskRowTop[x] != nonMaskValue || maskRowBottom[x] != nonMaskValue)
{
    outlinePixels4.emplace_back(x, y);
}
```

It never verified that the pixel itself is a non-mask pixel. As a result, every interior mask pixel that has at least one mask neighbor is incorrectly reported as an outline pixel, so `outlinePixels4` contains the full mask interior in addition to the true outline.

## Fix

Gate the check on the pixel being a non-mask pixel, matching the top/bottom row and left/right column passes already present in the same function:

```cpp
if (maskRow[x] == nonMaskValue && (maskRow[x - 1u] != nonMaskValue || maskRow[x + 1u] != nonMaskValue || maskRowTop[x] != nonMaskValue || maskRowBottom[x] != nonMaskValue))
{
    outlinePixels4.emplace_back(x, y);
}
```

## Verification

- Confirmed the header documentation (MaskAnalyzer.h:459) defines outline-4 pixels as non-mask pixels with a mask neighbor.
- Confirmed the top-center (line 373/383) and bottom-center (line 513/523) passes already use the `maskRow[x] != nonMaskValue` / `else` structure, i.e. they correctly skip mask pixels.
- Traced a concrete counterexample: a fully-mask 3x3 frame produces an outline entry for the interior pixel (1,1), which is a mask pixel and must not be an outline pixel.